### PR TITLE
fix package path for window environment

### DIFF
--- a/src/main/kotlin/com/arch/temp/tools/AnActionEventExt.kt
+++ b/src/main/kotlin/com/arch/temp/tools/AnActionEventExt.kt
@@ -111,7 +111,7 @@ fun AnActionEvent.getPackage(): String {
     if (path.indexOf(mainKotlin) > 0) {
         toPack = path.removeRange(0, path.indexOf(mainKotlin) + mainKotlin.length + 1)
     }
-    return toPack.replace("$SLASH", ".")
+    return toPack.replace("/", ".")
 }
 
 fun AnActionEvent.getPackFromManifest(): String {


### PR DESCRIPTION
Fix package path retrieval issue on Windows by updating path separator handling. 
Ensures correct package name extraction across platforms.